### PR TITLE
Added Packet size and Jumbo Frames subsection

### DIFF
--- a/6. Management and Operations/6. Management and Operations.md
+++ b/6. Management and Operations/6. Management and Operations.md
@@ -90,6 +90,8 @@ carrier, enterprise and data center scenarios.
 
 ## [Energy consumption](Energy%20consumption.md)
 
+## [Packet size and Jumbo Frames](Packet%20size%20and%20Jumbo%20Frames.md)
+
 <!-- Link lines generated automatically; do not delete -->
 
 ## [Basic Windows commands](Basic%20Windows%20commands.md)

--- a/6. Management and Operations/Packet size and Jumbo Frames.md
+++ b/6. Management and Operations/Packet size and Jumbo Frames.md
@@ -1,0 +1,48 @@
+## Packet size and Jumbo Frames
+
+### Fragmentation
+
+As already stated in the [<ins>The previous
+section</ins>](../3.%20Coexistence%20with%20Legacy%20IPv4/IPv6%20primary%20differences%20from%20IPv4.md)
+IPv6 does not allow intermediate routers to fragment packets. Instead,
+IPv6 pushes the responsibility of fragmentation to the source node. If a
+packet exceeds the MTU, it is either fragmented by the sender or
+dropped. This means the sender must use PMTUD
+[RFC7690](https://www.rfc-editor.org/info/rfc7690) to ensure that
+packets are sized appropriately for the smallest MTU along the path. The
+sender fragments packets if necessary before sending them. This require
+additional computation on the sender to fragment packet but there has
+been no significant performance implication is reported.
+
+### MTU Size and Jumbo Frames
+
+A jumbo frame is an Ethernet frame that is larger than the standard 1500
+bytes, commonly configured to be around 9000 bytes. If a router along
+the path has a smaller MTU when sending jumbo frames in an IPv4 network,
+it will fragment the frame. This can lead to higher fragmentation
+overhead because the larger the original frame, the more fragments it
+must be split into. Additionally, fragmentation adds processing
+complexity at both the router and the destination where reassembly
+occurs.
+
+IPv6 avoids this fragmentation overhead by relying on PMTUD
+[RFC7690](https://www.rfc-editor.org/info/rfc7690). If a jumbo frame
+exceeds the MTU of any network hop, the sender is responsible for
+fragmenting it before transmission. However, if properly configured, the
+sender can send larger packets efficiently without fragmentation,
+provided that the entire path supports jumbo frames. Ths allows IPv6 to
+handle larger packets more effectively because the Path MTU Discovery
+mechanism ensures that packets fit within the MTU of every hop along the
+route. This mechanism is defined in
+[RFC8201](https://www.rfc-editor.org/info/rfc8201).
+
+“Jumbo Payload Option” in IPv6
+[RFC2675](https://www.rfc-editor.org/info/rfc2675) allows packets larger
+than 65,535 bytes (the maximum payload size for standard IPv6 packets)
+to be transmitted. This option is included in the Hop-by-Hop Options
+header and enables IPv6 to support super jumbo frames efficiently, even
+when dealing with extremely large packet sizes. This mechanism
+simplifies the handling of large packets without requiring them to be
+split into smaller fragments. If a network supports large enough MTUs,
+IPv6 can use this option to transmit large frames without intermediate
+fragmentation.


### PR DESCRIPTION
Hello. I tried to write a subsection on Packet size and jumbo frames in IPv6 as suggested in [issue 94](https://github.com/becarpenter/book6/issues/94). Please comment on any issue it might have.