### PR TITLE
close ins tag

### DIFF
--- a/04. Security/Filtering.md
+++ b/04. Security/Filtering.md
@@ -88,7 +88,7 @@ additional actions are recommended in addition to the basic rule of
 the transmission of all extension headers in transit.
 
 Limiting ND messages on the link is discussed in
-[<ins>Address resolution<ins>](../02.%20IPv6%20Basic%20Technology/Address%20resolution.md).
+[<ins>Address resolution</ins>](../02.%20IPv6%20Basic%20Technology/Address%20resolution.md).
 
 There is a risk for IPv4-only networks caused by IPv6 preference
 programmed into hosts. The activation of IPv6 by a malicious node could


### PR DESCRIPTION
When checking the epub for errors with epubcheck it found a non-closed tag
```
FATAL(RSC-016): IPv6 textbook.epub/EPUB/text/ch005.xhtml(68,124): Fatal Error while parsing file: The element type "ins" must be terminated by the matching end-tag "</ins>".
```